### PR TITLE
adding colormaps functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ For a development installation (requires npm),
     $ pip install -e .
     $ jupyter nbextension install --py --symlink --sys-prefix yt_pycanvas
     $ jupyter nbextension enable --py --sys-prefix yt_pycanvas
+
+You will also likely have to include this in your `jupyter_notebook_config.py`:
+
+```
+import mimetypes
+mimetypes.add_type('application/wasm', '.wasm')
+```
+
+This will allow wasm to be served through the correct MIME type.

--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -1,32 +1,39 @@
 var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
 var yt_tools = require('yt-tools');
-var mpl_cmap_obj = {}
 
 var CMapModel = widgets.WidgetModel.extend({
 
     defaults: function() {
-        },
+        return _.extend(widgets.WidgetModel.prototype.defaults.call(this), {
+            _model_name: 'CMapModel',
+            _model_module: 'yt-jscanvas',
+            _model_module_version: '0.1.0'
+        });
+    },
 
     initialize: function() {
         widgets.WidgetModel.prototype.initialize.apply(this);
 
         console.log('initializing colormaps object in WASM')
         this.colormaps = yt_tools.Colormaps.new();
-        this.add_mpl_colormaps();
+        this.add_mpl_colormaps_to_wasm();
 
     },
 
-    add_mpl_colormaps: function() {
+    add_mpl_colormaps_to_wasm: function() {
         // initializes the colormaps module from yt tools and adds the 
         // arrays stored in the self.cmaps dict on the python side into
         // the colormaps object in wasm.
-        //
+        
+        var mpl_cmap_obj = this.get('cmaps');
         var mapname = '';
-        var maptable;
         for (mapname in mpl_cmap_obj) {
-            console.log('adding in colormap of size ')
-            this.colormaps.add_cmap(mapname, mpl_cmap_obj)
+            console.log('adding in colormap');
+            // getArray is used to access something passed with NDArrayWidget. 
+            var maptable = ipydatawidgets.getArray(somethingmapname);
+            console.log(maptable);
+            this.colormaps.add_cmap(mapname, maptable)
         },
     }, 
 }, {

--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -8,15 +8,19 @@ var CMapModel = widgets.WidgetModel.extend({
         return _.extend(widgets.WidgetModel.prototype.defaults.call(this), {
             _model_name: 'CMapModel',
             _model_module: 'yt-jscanvas',
-            _model_module_version: '0.1.0'
+            _model_module_version: '0.1.0',
+
+            cmaps: undefined
         });
     },
 
     initialize: function() {
-        widgets.WidgetModel.prototype.initialize.apply(this);
+        // widgets.WidgetModel.prototype.initialize.apply(this);
 
-        console.log('initializing colormaps object in WASM')
-        this.colormaps = yt_tools.Colormaps.new();
+        console.log('initializing colormaps object in WASM');
+        yt_tools.booted.then(function() {
+            this.colormaps = yt_tools.Colormaps.new();
+        }.bind(this));
         this.add_mpl_colormaps_to_wasm();
 
     },
@@ -27,15 +31,22 @@ var CMapModel = widgets.WidgetModel.extend({
         // the colormaps object in wasm.
         
         var mpl_cmap_obj = this.get('cmaps');
-        var mapname = '';
-        for (mapname in mpl_cmap_obj) {
-            console.log('adding in colormap');
+        console.log(typeof mpl_cmap_obj)
+        // for (var mapname in mpl_cmap_obj) {
+            // console.log('adding in colormap');
+            // console.log(typeof mapname);
+            // console.log(typeof mpl_cmap_obj);
             // getArray is used to access something passed with NDArrayWidget. 
-            var maptable = ipydatawidgets.getArray(somethingmapname);
-            console.log(maptable);
-            this.colormaps.add_cmap(mapname, maptable)
-        },
+            // var maptable = ipydatawidgets.getArray(somethingmapname);
+            // var maptable = mpl_cmap_obj[mapname];
+            // console.log(mapname, maptable);
+            // this.colormaps.add_cmap(mapname, maptable)
+        // },
     }, 
+// }, {
+//    serializers: _.extend({
+//        cmaps: {deserialize: widgets.unpack_models}
+//    }, widgets.WidgetModel.serializers),
 }, {
     model_module: 'yt-jscanvas',
     model_name: 'CMapModel',

--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -31,22 +31,16 @@ var CMapModel = widgets.WidgetModel.extend({
         // the colormaps object in wasm.
         
         var mpl_cmap_obj = this.get('cmaps');
-        console.log(typeof mpl_cmap_obj)
-        // for (var mapname in mpl_cmap_obj) {
-            // console.log('adding in colormap');
-            // console.log(typeof mapname);
-            // console.log(typeof mpl_cmap_obj);
-            // getArray is used to access something passed with NDArrayWidget. 
-            // var maptable = ipydatawidgets.getArray(somethingmapname);
-            // var maptable = mpl_cmap_obj[mapname];
-            // console.log(mapname, maptable);
-            // this.colormaps.add_cmap(mapname, maptable)
-        // },
+        console.log(mpl_cmap_obj);
+        console.log(Object.keys(mpl_cmap_obj));
+        for (var mapname in mpl_cmap_obj) {
+            if (mpl_cmap_obj.hasOwnProperty(mapname)) {
+                var maptable = mpl_cmap_obj[mapname];
+                console.log(mapname, maptable);
+                // this.colormaps.add_cmap(mapnanme, maptable);
+            }
+        }
     }, 
-// }, {
-//    serializers: _.extend({
-//        cmaps: {deserialize: widgets.unpack_models}
-//    }, widgets.WidgetModel.serializers),
 }, {
     model_module: 'yt-jscanvas',
     model_name: 'CMapModel',

--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -10,15 +10,16 @@ var CMapModel = widgets.WidgetModel.extend({
             _model_module: 'yt-jscanvas',
             _model_module_version: '0.1.0',
 
-            cmaps: undefined
+            cmaps: undefined,
         });
     },
 
     initialize: function() {
-        // widgets.WidgetModel.prototype.initialize.apply(this);
-
         console.log('initializing colormaps object in WASM');
-        this.add_mpl_colormaps_to_wasm();
+        this.add_mpl_colormaps_to_wasm().then(function(colormaps) {
+            console.log('double checking refs');
+            console.log(colormaps.normalize('viridis', [1.0], true));
+        });
 
     },
 
@@ -27,7 +28,7 @@ var CMapModel = widgets.WidgetModel.extend({
         // arrays stored in the self.cmaps dict on the python side into
         // the colormaps object in wasm.
         
-        yt_tools.booted.then(function() {
+        return yt_tools.booted.then(function() {
             console.log('Sending available cmaps to WASM...')
             this.colormaps = yt_tools.Colormaps.new();
         
@@ -43,6 +44,7 @@ var CMapModel = widgets.WidgetModel.extend({
             console.log(this.colormaps.normalize('viridis', [1.0], true));
             console.log(this.colormaps.normalize('jet', [1.0], true));
             console.log(this.colormaps.normalize('tab20', [1.0], true));
+            return this.colormaps
         }.bind(this));
     }, 
 }, {

--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -11,16 +11,13 @@ var CMapModel = widgets.WidgetModel.extend({
             _model_module_version: '0.1.0',
 
             cmaps: undefined,
+            map_name: undefined,
         });
     },
 
     initialize: function() {
         console.log('initializing colormaps object in WASM');
-        this.add_mpl_colormaps_to_wasm().then(function(colormaps) {
-            console.log('double checking refs');
-            console.log(colormaps.normalize('viridis', [1.0], true));
-        });
-
+        this.map_name = this.get('map_name')
     },
 
     normalize: function(name, buffer, take_log) {
@@ -49,9 +46,9 @@ var CMapModel = widgets.WidgetModel.extend({
                 }
             }
             // just check that we can access a few of the cmaps 
-            console.log(this.colormaps.normalize('viridis', [1.0], true));
-            console.log(this.colormaps.normalize('jet', [1.0], true));
-            console.log(this.colormaps.normalize('tab20', [1.0], true));
+            // console.log(this.colormaps.normalize('viridis', [1.0], true));
+            // console.log(this.colormaps.normalize('jet', [1.0], true));
+            // console.log(this.colormaps.normalize('tab20', [1.0], true));
             return this.colormaps
         }.bind(this));
     }, 

--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -18,9 +18,6 @@ var CMapModel = widgets.WidgetModel.extend({
         // widgets.WidgetModel.prototype.initialize.apply(this);
 
         console.log('initializing colormaps object in WASM');
-        yt_tools.booted.then(function() {
-            this.colormaps = yt_tools.Colormaps.new();
-        }.bind(this));
         this.add_mpl_colormaps_to_wasm();
 
     },
@@ -30,16 +27,23 @@ var CMapModel = widgets.WidgetModel.extend({
         // arrays stored in the self.cmaps dict on the python side into
         // the colormaps object in wasm.
         
-        var mpl_cmap_obj = this.get('cmaps');
-        console.log(mpl_cmap_obj);
-        console.log(Object.keys(mpl_cmap_obj));
-        for (var mapname in mpl_cmap_obj) {
-            if (mpl_cmap_obj.hasOwnProperty(mapname)) {
-                var maptable = mpl_cmap_obj[mapname];
-                console.log(mapname, maptable);
-                // this.colormaps.add_cmap(mapnanme, maptable);
+        yt_tools.booted.then(function() {
+            console.log('Sending available cmaps to WASM...')
+            this.colormaps = yt_tools.Colormaps.new();
+        
+            var mpl_cmap_obj = this.get('cmaps');
+            console.log("imported the following maps:", Object.keys(mpl_cmap_obj));
+            for (var mapname in mpl_cmap_obj) {
+                if (mpl_cmap_obj.hasOwnProperty(mapname)) {
+                    var maptable = mpl_cmap_obj[mapname];
+                    this.colormaps.add_colormap(mapname, maptable);
+                }
             }
-        }
+            // just check that we can access a few of the cmaps 
+            console.log(this.colormaps.normalize('viridis', [1.0], true));
+            console.log(this.colormaps.normalize('jet', [1.0], true));
+            console.log(this.colormaps.normalize('tab20', [1.0], true));
+        }.bind(this));
     }, 
 }, {
     model_module: 'yt-jscanvas',

--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -19,34 +19,31 @@ var CMapModel = widgets.WidgetModel.extend({
     },
 
     normalize: function(name, buffer, take_log) {
+        // normalizes a given buffer with a colormap name. Requires colormaps
+        // to be loaded in to wasm, so requires add_mpl_colormaps to be called 
+        // at this time. 
         return this.add_mpl_colormaps_to_wasm().then(function(colormaps) {
-            console.log('normalizing buffer with %s colormap', name);
             array = colormaps.normalize(name, buffer, take_log);
             return array
         });
     },
 
     add_mpl_colormaps_to_wasm: function() {
-        // initializes the colormaps module from yt tools and adds the 
+        // initializes the wasm colormaps module from yt tools and adds the 
         // arrays stored in the self.cmaps dict on the python side into
         // the colormaps object in wasm.
         
         return yt_tools.booted.then(function(yt_tools) {
-            console.log('Sending available cmaps to WASM...')
             this.colormaps = yt_tools.Colormaps.new();
         
             var mpl_cmap_obj = this.get('cmaps');
-            console.log("imported the following maps:", Object.keys(mpl_cmap_obj));
+            // console.log("imported the following maps:", Object.keys(mpl_cmap_obj));
             for (var mapname in mpl_cmap_obj) {
                 if (mpl_cmap_obj.hasOwnProperty(mapname)) {
                     var maptable = mpl_cmap_obj[mapname];
                     this.colormaps.add_colormap(mapname, maptable);
                 }
             }
-            // just check that we can access a few of the cmaps 
-            // console.log(this.colormaps.normalize('viridis', [1.0], true));
-            // console.log(this.colormaps.normalize('jet', [1.0], true));
-            // console.log(this.colormaps.normalize('tab20', [1.0], true));
             return this.colormaps
         }.bind(this));
     }, 

--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -1,0 +1,40 @@
+var widgets = require('@jupyter-widgets/base');
+var ipydatawidgets = require('jupyter-dataserializers');
+var yt_tools = require('yt-tools');
+var mpl_cmap_obj = {}
+
+var CMapModel = widgets.WidgetModel.extend({
+
+    defaults: function() {
+        },
+
+    initialize: function() {
+        widgets.WidgetModel.prototype.initialize.apply(this);
+
+        console.log('initializing colormaps object in WASM')
+        this.colormaps = yt_tools.Colormaps.new();
+        this.add_mpl_colormaps();
+
+    },
+
+    add_mpl_colormaps: function() {
+        // initializes the colormaps module from yt tools and adds the 
+        // arrays stored in the self.cmaps dict on the python side into
+        // the colormaps object in wasm.
+        //
+        var mapname = '';
+        var maptable;
+        for (mapname in mpl_cmap_obj) {
+            console.log('adding in colormap of size ')
+            this.colormaps.add_cmap(mapname, mpl_cmap_obj)
+        },
+    }, 
+}, {
+    model_module: 'yt-jscanvas',
+    model_name: 'CMapModel',
+    model_module_version: '0.1.0',
+});
+
+module.exports = {
+    CMapModel : CMapModel,
+};

--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -23,6 +23,14 @@ var CMapModel = widgets.WidgetModel.extend({
 
     },
 
+    normalize: function(name, buffer, take_log) {
+        return this.add_mpl_colormaps_to_wasm().then(function(colormaps) {
+            console.log('normalizing buffer with %s colormap', name);
+            array = colormaps.normalize(name, buffer, take_log);
+            return array
+        });
+    },
+
     add_mpl_colormaps_to_wasm: function() {
         // initializes the colormaps module from yt tools and adds the 
         // arrays stored in the self.cmaps dict on the python side into

--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -11,13 +11,11 @@ var CMapModel = widgets.WidgetModel.extend({
             _model_module_version: '0.1.0',
 
             cmaps: undefined,
-            map_name: undefined,
         });
     },
 
     initialize: function() {
         console.log('initializing colormaps object in WASM');
-        this.map_name = this.get('map_name')
     },
 
     normalize: function(name, buffer, take_log) {

--- a/js/lib/fixed_res_buffer.js
+++ b/js/lib/fixed_res_buffer.js
@@ -1,6 +1,7 @@
 var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
 var yt_tools = require('yt-tools');
+var cmaps = require('./colormaps.js')
 
 var FRBModel = widgets.DOMWidgetModel.extend({
     defaults: _.extend({}, widgets.DOMWidgetModel.prototype.defaults, {

--- a/js/lib/fixed_res_buffer.js
+++ b/js/lib/fixed_res_buffer.js
@@ -1,7 +1,6 @@
 var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
 var yt_tools = require('yt-tools');
-// var CMapModel = require('./colormaps.js').CMapModel;
 
 var FRBModel = widgets.DOMWidgetModel.extend({
     defaults: _.extend({}, widgets.DOMWidgetModel.prototype.defaults, {
@@ -50,10 +49,12 @@ var FRBView = widgets.DOMWidgetView.extend({
             this.colormaps = this.model.get('colormaps');
             console.log('trying colormaps ref with model');
             console.log('colormaps reference:', this.colormaps);
+            this.map_name = this.colormaps.map_name;
+            console.log('colormap used:' , this.map_name);
             this.frb = yt_tools.FixedResolutionBuffer.new(
               this.model.get('width'),
               this.model.get('height'),
-              0.45, 0.55, 0.45, 0.55
+              0.45, 0.65, 0.45, 0.65
             );
             this.varmesh = yt_tools.VariableMesh.new(
                 this.model.get("px").data,
@@ -64,7 +65,7 @@ var FRBView = widgets.DOMWidgetView.extend({
             );
             console.log(this.frb.deposit(this.varmesh));
             console.log(this.frb.get_buffer());
-            this.colormaps.normalize("viridis",
+            this.colormaps.normalize(this.map_name,
                 this.frb.get_buffer(), true).then(function(array) {
                 im =  array;
                 console.log(im);

--- a/js/lib/fixed_res_buffer.js
+++ b/js/lib/fixed_res_buffer.js
@@ -17,6 +17,7 @@ var FRBModel = widgets.DOMWidgetModel.extend({
         val: undefined,
         width: 512,
         height: 512,
+        colormap_name: 'viridis',
         colormaps: undefined,
     }),
 }, {
@@ -45,11 +46,14 @@ var FRBView = widgets.DOMWidgetView.extend({
         this.ctx.imageSmoothingEnabled = false;
         this.model.on('change:width', this.width_changed, this);
         this.model.on('change:height', this.height_changed, this);
+        this.colormap_changed();
+        this.model.on('change:colormap_name', this.colormap_changed, this);
+        console.log('colormap used:' , this.map_name);
         yt_tools.booted.then(function() {
             this.colormaps = this.model.get('colormaps');
             console.log('trying colormaps ref with model');
             console.log('colormaps reference:', this.colormaps);
-            this.map_name = this.colormaps.map_name;
+            // this.map_name = this.model.get('colormap_name');
             console.log('colormap used:' , this.map_name);
             this.frb = yt_tools.FixedResolutionBuffer.new(
               this.model.get('width'),
@@ -97,6 +101,10 @@ var FRBView = widgets.DOMWidgetView.extend({
 
     height_changed: function() {
       $(this.canvas).height(this.model.get('height'));
+    },
+
+    colormap_changed: function() {
+      this.map_name = this.model.get('colormap_name');
     }
 });
 

--- a/js/lib/fixed_res_buffer.js
+++ b/js/lib/fixed_res_buffer.js
@@ -1,0 +1,98 @@
+var widgets = require('@jupyter-widgets/base');
+var ipydatawidgets = require('jupyter-dataserializers');
+var yt_tools = require('yt-tools');
+
+var FRBModel = widgets.DOMWidgetModel.extend({
+    defaults: _.extend({}, widgets.DOMWidgetModel.prototype.defaults, {
+        _model_name : 'FRBMovel',
+        _view_name : 'FRBView',
+        _model_module : 'yt-jscanvas',
+        _view_module : 'yt-jscanvas',
+        _model_module_version : '0.1.0',
+        _view_module_version : '0.1.0',
+        px: undefined,
+        py: undefined,
+        pdx: undefined,
+        pdy: undefined,
+        val: undefined,
+        width: 512,
+        height: 512
+    }),
+}, {
+    serializers: _.extend({
+      px: ipydatawidgets.data_union_array_serialization,
+      py: ipydatawidgets.data_union_array_serialization,
+      pdx: ipydatawidgets.data_union_array_serialization,
+      pdy: ipydatawidgets.data_union_array_serialization,
+      val: ipydatawidgets.data_union_array_serialization
+    }, widgets.DOMWidgetModel.serializers),
+});
+
+// Custom View. Renders the widget model.
+var FRBView = widgets.DOMWidgetView.extend({
+    render: function() {
+        this.canvas = document.createElement('canvas');
+        $(this.canvas)
+          .css("max-width", "100%")
+          .css("min-width", "100px")
+          .css("min-height", "100px")
+          .height(this.model.get('height'))
+          .width(this.model.get('width'))
+          .appendTo(this.el);
+        this.ctx = this.canvas.getContext('2d');
+        this.ctx.imageSmoothingEnabled = false;
+        this.model.on('change:width', this.width_changed, this);
+        this.model.on('change:height', this.height_changed, this);
+        yt_tools.booted.then(function() {
+            this.frb = yt_tools.FixedResolutionBuffer.new(
+              this.model.get('width'),
+              this.model.get('height'),
+              0.45, 0.55, 0.45, 0.55
+            );
+            this.colormaps = yt_tools.Colormaps.new();
+            this.varmesh = yt_tools.VariableMesh.new(
+                this.model.get("px").data,
+                this.model.get("py").data,
+                this.model.get("pdx").data,
+                this.model.get("pdy").data,
+                this.model.get("val").data
+            );
+            console.log(this.frb.deposit(this.varmesh));
+            console.log(this.frb.get_buffer());
+            im = this.colormaps.normalize("default",
+              this.frb.get_buffer(), true);
+            console.log(im);
+            this.imageData = this.ctx.createImageData(
+                this.model.get('width'), this.model.get('height'),
+            );
+            this.imageData.data.set(im);
+            this.redrawCanvasImage();
+        }.bind(this));
+
+    },
+
+    redrawCanvasImage: function() {
+        var nx = this.model.get('width');
+        var ny = this.model.get('height');
+        var canvasWidth  = $(this.canvas).width();
+        var canvasHeight = $(this.canvas).height();
+        // Clear out image first
+        createImageBitmap(this.imageData, 0, 0, nx, ny).then(function(bitmap){
+              this.ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+              this.ctx.drawImage(bitmap, 0, 0, canvasWidth, canvasHeight);
+        }.bind(this));
+    },
+
+    width_changed: function() {
+      $(this.canvas).width(this.model.get('width'));
+    },
+
+    height_changed: function() {
+      $(this.canvas).height(this.model.get('height'));
+    }
+});
+
+module.exports = {
+    FRBModel : FRBModel,
+    FRBView : FRBView
+};

--- a/js/lib/image_canvas.js
+++ b/js/lib/image_canvas.js
@@ -2,6 +2,7 @@ var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
 var yt_tools = require('yt-tools');
 var frb = require('./fixed_res_buffer.js');
+var cmaps = require('./colormaps.js')
 
 // Custom Model. Custom widgets models must at least provide default values
 // for model attributes, including
@@ -106,5 +107,6 @@ module.exports = {
     ImageCanvasModel : ImageCanvasModel,
     ImageCanvasView : ImageCanvasView,
     FRBView: frb.FRBView,
-    FRBModel: frb.FRBModel
+    FRBModel: frb.FRBModel,
+    CMapModel: cmaps.CMapModel
 };

--- a/js/lib/image_canvas.js
+++ b/js/lib/image_canvas.js
@@ -1,6 +1,6 @@
 var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
-var _ = require('lodash');
+var yt_tools = require('yt-tools');
 
 // Custom Model. Custom widgets models must at least provide default values
 // for model attributes, including

--- a/js/lib/image_canvas.js
+++ b/js/lib/image_canvas.js
@@ -1,6 +1,7 @@
 var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
 var yt_tools = require('yt-tools');
+var frb = require('./fixed_res_buffer.js');
 
 // Custom Model. Custom widgets models must at least provide default values
 // for model attributes, including
@@ -103,5 +104,7 @@ var ImageCanvasView = widgets.DOMWidgetView.extend({
 
 module.exports = {
     ImageCanvasModel : ImageCanvasModel,
-    ImageCanvasView : ImageCanvasView
+    ImageCanvasView : ImageCanvasView,
+    FRBView: frb.FRBView,
+    FRBModel: frb.FRBModel
 };

--- a/js/lib/image_canvas.js
+++ b/js/lib/image_canvas.js
@@ -29,7 +29,7 @@ var ImageCanvasModel = widgets.DOMWidgetModel.extend({
     }),
 }, {
     serializers: _.extend({
-        image_array: { deserialize: ipydatawidgets.JSONToUnionArray },
+      image_array: ipydatawidgets.data_union_array_serialization
     }, widgets.DOMWidgetModel.serializers),
 });
 
@@ -40,7 +40,7 @@ var ImageCanvasView = widgets.DOMWidgetView.extend({
     render: function() {
         this.canvas = document.createElement('canvas');
         $(this.canvas)
-          .width('100%')
+          .width('auto')
           .height('100%')
           .appendTo(this.el);
         this.ctx = this.canvas.getContext('2d');

--- a/js/lib/image_canvas.js
+++ b/js/lib/image_canvas.js
@@ -25,7 +25,9 @@ var ImageCanvasModel = widgets.DOMWidgetModel.extend({
         _view_module : 'yt-jscanvas',
         _model_module_version : '0.1.0',
         _view_module_version : '0.1.0',
-        image_array: undefined
+        image_array: undefined,
+        width: 256,
+        height: 256
     }),
 }, {
     serializers: _.extend({
@@ -40,8 +42,11 @@ var ImageCanvasView = widgets.DOMWidgetView.extend({
     render: function() {
         this.canvas = document.createElement('canvas');
         $(this.canvas)
-          .width('auto')
-          .height('100%')
+          .css("max-width", "100%")
+          .css("min-width", "100px")
+          .css("min-height", "100px")
+          .height(this.model.get('height'))
+          .width(this.model.get('width'))
           .appendTo(this.el);
         this.ctx = this.canvas.getContext('2d');
         this.ctx.imageSmoothingEnabled = false;
@@ -50,6 +55,8 @@ var ImageCanvasView = widgets.DOMWidgetView.extend({
         this.imageShape = new Array(3);
         this.imageShape[0] = this.imageShape[1] = this.imageShape[2] = -1;
         this.model.on('change:image_array', this.image_array_changed, this);
+        this.model.on('change:width', this.width_changed, this);
+        this.model.on('change:height', this.height_changed, this);
         this.image_array_changed();
     },
 
@@ -82,6 +89,14 @@ var ImageCanvasView = widgets.DOMWidgetView.extend({
         }
         this.imageData.data.set(this.data.data);
         this.redrawCanvasImage();
+    },
+
+    width_changed: function() {
+      $(this.canvas).width(this.model.get('width'));
+    },
+
+    height_changed: function() {
+      $(this.canvas).height(this.model.get('height'));
     }
 });
 

--- a/js/package.json
+++ b/js/package.json
@@ -24,7 +24,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "webpack": "^4.6.0",
+    "webpack": "^4.8.3",
     "webpack-cli": "^2.0.14",
     "wasm-loader": "^1.3.0",
     "rimraf": "^2.6.1"

--- a/js/package.json
+++ b/js/package.json
@@ -20,17 +20,21 @@
   ],
   "scripts": {
     "clean": "rimraf dist/",
-    "prepublish": "webpack",
+    "prepublish": "webpack --display-error-details",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "webpack": "^3.5.5",
+    "webpack": "^4.6.0",
+    "webpack-cli": "^2.0.14",
+    "wasm-loader": "^1.3.0",
     "rimraf": "^2.6.1"
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1.0.0",
     "jupyter-dataserializers": "^1.1.2",
     "jupyter-datawidgets": "^4.0.1",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "wasm-dce": "^1.0.2",
+    "yt-tools": "0.1.0"
   }
 }

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -4,7 +4,8 @@ var version = require('./package.json').version;
 // Custom webpack rules are generally the same for all webpack bundles, hence
 // stored in a separate local variable.
 var rules = [
-    { test: /\.css$/, use: ['style-loader', 'css-loader']}
+    { test: /\.css$/, use: ['style-loader', 'css-loader'] },
+    { test: /\.wasm$/, type: 'webassembly/experimental' }
 ]
 
 

--- a/yt_pycanvas/colormaps/colormaps.py
+++ b/yt_pycanvas/colormaps/colormaps.py
@@ -33,9 +33,9 @@ class ColorMaps(ipywidgets.Widget):
             cmap_list =  mplcm.cmap_d.keys()
             for colormap in cmap_list:
                 cmap = mplcm.get_cmap(colormap)
-                vals = cmap(np.mgrid[0.0:1.0:256j])
+                vals = (cmap(np.mgrid[0.0:1.0:256j])*255).astype("uint8")
                 # right now let's just flatten the arrays. Later we can
                 # serialize each cmap on its own.
-                table = vals.tolist()
+                table = vals.flatten().tolist()
                 colormaps[colormap] = table
         return colormaps

--- a/yt_pycanvas/colormaps/colormaps.py
+++ b/yt_pycanvas/colormaps/colormaps.py
@@ -1,0 +1,26 @@
+import ipywidgets as ipywidgets
+import numpy as np
+
+@ipywidgets.register
+class ColorMaps(ipywidgets.Widget):
+
+    """Colormapping widget used for rendering views """
+
+    def __init__(self):
+        print("getting colormaps from matplotlib...")
+
+        self.cmaps = {}
+
+        try:
+            import matplotlib.cm as mplcm
+        except ImportError:
+            print("can't import matplotlib.cm")
+        else:
+            cmap_list =  mplcm.cmap_d.keys()
+            for colormap in cmap_list:
+                cmap = mplcm.get_cmap(colormap)
+                vals = cmap(np.mgrid[0.0:1.0:256j])
+                self.cmaps[colormap] = vals
+
+        super(ColorMaps, self).__init__()
+

--- a/yt_pycanvas/colormaps/colormaps.py
+++ b/yt_pycanvas/colormaps/colormaps.py
@@ -1,16 +1,28 @@
 import ipywidgets as ipywidgets
+from ipydatawidgets import DataUnion, shape_constraints, \
+        data_union_serialization
 import numpy as np
+import traitlets
 
 @ipywidgets.register
 class ColorMaps(ipywidgets.Widget):
+    """Colormapping widget used to collect available colormaps """
 
-    """Colormapping widget used for rendering views """
+    _model_name = traitlets.Unicode('CMapModel').tag(sync=True)
+    _model_module = traitlets.Unicode('yt-jscanvas').tag(sync=True)
+    _model_module_version = traitlets.Unicode('^0.1.0').tag(sync=True)
+    # note: maybe sync=True is unnecessary here since this isn't directly sent
+    # to the browser?
 
     def __init__(self):
         print("getting colormaps from matplotlib...")
 
-        self.cmaps = {}
+        super(ColorMaps, self).__init__()
+        self.cmaps = self.get_mpl_cmaps()
 
+    def get_mpl_cmaps(self):
+        """ Adds available colormaps from matplotlib."""
+        cmaps = {}
         try:
             import matplotlib.cm as mplcm
         except ImportError:
@@ -20,7 +32,6 @@ class ColorMaps(ipywidgets.Widget):
             for colormap in cmap_list:
                 cmap = mplcm.get_cmap(colormap)
                 vals = cmap(np.mgrid[0.0:1.0:256j])
-                self.cmaps[colormap] = vals
-
-        super(ColorMaps, self).__init__()
-
+                cmaps[colormap] = vals
+        # maybe trying to pass the Dict of arrays will work? Not sure yet.
+        return traitlets.Dict(cmaps).tag(sync=True)

--- a/yt_pycanvas/colormaps/colormaps.py
+++ b/yt_pycanvas/colormaps/colormaps.py
@@ -15,14 +15,11 @@ class ColorMaps(ipywidgets.Widget):
     _model_module_version = traitlets.Unicode('^0.1.0').tag(sync=True)
 
     cmaps = traitlets.Dict({}).tag(sync=True, config=True)
-    map_name = traitlets.Unicode("").tag(sync=True,
-            config=True)
 
     def __init__(self):
         print("getting colormaps from matplotlib...")
 
         self.cmaps = self.get_mpl_cmaps()
-        self.map_name = 'viridis'
         super(ColorMaps, self).__init__()
 
     def get_mpl_cmaps(self):

--- a/yt_pycanvas/colormaps/colormaps.py
+++ b/yt_pycanvas/colormaps/colormaps.py
@@ -4,6 +4,8 @@ from ipydatawidgets import DataUnion, shape_constraints, \
 import numpy as np
 import traitlets
 
+to_json = ipywidgets.widget_serialization['to_json']
+
 @ipywidgets.register
 class ColorMaps(ipywidgets.Widget):
     """Colormapping widget used to collect available colormaps """
@@ -11,14 +13,15 @@ class ColorMaps(ipywidgets.Widget):
     _model_name = traitlets.Unicode('CMapModel').tag(sync=True)
     _model_module = traitlets.Unicode('yt-jscanvas').tag(sync=True)
     _model_module_version = traitlets.Unicode('^0.1.0').tag(sync=True)
-    # note: maybe sync=True is unnecessary here since this isn't directly sent
-    # to the browser?
+
+    cmaps = traitlets.Dict({}).tag(sync=True)
 
     def __init__(self):
         print("getting colormaps from matplotlib...")
 
         super(ColorMaps, self).__init__()
         self.cmaps = self.get_mpl_cmaps()
+        cmaps = traitlets.Dict(self.cmaps).tag(sync=True)
 
     def get_mpl_cmaps(self):
         """ Adds available colormaps from matplotlib."""
@@ -34,4 +37,4 @@ class ColorMaps(ipywidgets.Widget):
                 vals = cmap(np.mgrid[0.0:1.0:256j])
                 cmaps[colormap] = vals
         # maybe trying to pass the Dict of arrays will work? Not sure yet.
-        return traitlets.Dict(cmaps).tag(sync=True)
+        return cmaps

--- a/yt_pycanvas/colormaps/colormaps.py
+++ b/yt_pycanvas/colormaps/colormaps.py
@@ -14,18 +14,17 @@ class ColorMaps(ipywidgets.Widget):
     _model_module = traitlets.Unicode('yt-jscanvas').tag(sync=True)
     _model_module_version = traitlets.Unicode('^0.1.0').tag(sync=True)
 
-    cmaps = traitlets.Dict({}).tag(sync=True)
+    cmaps = traitlets.Dict({}).tag(sync=True, config=True)
 
     def __init__(self):
         print("getting colormaps from matplotlib...")
 
-        super(ColorMaps, self).__init__()
         self.cmaps = self.get_mpl_cmaps()
-        cmaps = traitlets.Dict(self.cmaps).tag(sync=True)
+        super(ColorMaps, self).__init__()
 
     def get_mpl_cmaps(self):
         """ Adds available colormaps from matplotlib."""
-        cmaps = {}
+        colormaps = {}
         try:
             import matplotlib.cm as mplcm
         except ImportError:
@@ -35,6 +34,8 @@ class ColorMaps(ipywidgets.Widget):
             for colormap in cmap_list:
                 cmap = mplcm.get_cmap(colormap)
                 vals = cmap(np.mgrid[0.0:1.0:256j])
-                cmaps[colormap] = vals
-        # maybe trying to pass the Dict of arrays will work? Not sure yet.
-        return cmaps
+                # right now let's just flatten the arrays. Later we can
+                # serialize each cmap on its own.
+                table = vals.tolist()
+                colormaps[colormap] = table
+        return colormaps

--- a/yt_pycanvas/colormaps/colormaps.py
+++ b/yt_pycanvas/colormaps/colormaps.py
@@ -15,11 +15,14 @@ class ColorMaps(ipywidgets.Widget):
     _model_module_version = traitlets.Unicode('^0.1.0').tag(sync=True)
 
     cmaps = traitlets.Dict({}).tag(sync=True, config=True)
+    map_name = traitlets.Unicode("").tag(sync=True,
+            config=True)
 
     def __init__(self):
         print("getting colormaps from matplotlib...")
 
         self.cmaps = self.get_mpl_cmaps()
+        self.map_name = 'viridis'
         super(ColorMaps, self).__init__()
 
     def get_mpl_cmaps(self):

--- a/yt_pycanvas/image_canvas.py
+++ b/yt_pycanvas/image_canvas.py
@@ -18,3 +18,5 @@ class ImageCanvas(ipywidgets.DOMWidget):
     image_array = DataUnion(dtype=np.uint8,
             shape_constraint=rgba_image_shape).tag(sync=True,
                     **data_union_serialization)
+    width = traitlets.Int(256).tag(sync=True)
+    height = traitlets.Int(256).tag(sync=True)

--- a/yt_pycanvas/image_canvas.py
+++ b/yt_pycanvas/image_canvas.py
@@ -4,6 +4,8 @@ from ipydatawidgets import DataUnion, shape_constraints, \
         data_union_serialization
 import numpy as np
 
+from .colormaps.colormaps import ColorMaps
+
 rgba_image_shape = shape_constraints(None, None, 4)
 vmesh_shape = shape_constraints(None)
 

--- a/yt_pycanvas/image_canvas.py
+++ b/yt_pycanvas/image_canvas.py
@@ -3,6 +3,7 @@ import traitlets
 from ipydatawidgets import DataUnion, shape_constraints, \
         data_union_serialization
 import numpy as np
+from ipywidgets import widget_serialization
 
 from .colormaps.colormaps import ColorMaps
 
@@ -50,3 +51,10 @@ class FRBViewer(ipywidgets.DOMWidget):
     val = DataUnion(dtype=np.float64,
             shape_constraint=vmesh_shape).tag(sync = True,
                     **data_union_serialization)
+    colormaps = traitlets.Instance(ColorMaps).tag(sync = True,
+            **widget_serialization)
+
+    @traitlets.default('colormaps')
+    def _colormap_load(self):
+        return ColorMaps()
+

--- a/yt_pycanvas/image_canvas.py
+++ b/yt_pycanvas/image_canvas.py
@@ -51,6 +51,8 @@ class FRBViewer(ipywidgets.DOMWidget):
     val = DataUnion(dtype=np.float64,
             shape_constraint=vmesh_shape).tag(sync = True,
                     **data_union_serialization)
+    colormap_name = traitlets.Unicode('viridis').tag(sync=True,
+            config=True)
     colormaps = traitlets.Instance(ColorMaps).tag(sync = True,
             **widget_serialization)
 

--- a/yt_pycanvas/image_canvas.py
+++ b/yt_pycanvas/image_canvas.py
@@ -5,6 +5,7 @@ from ipydatawidgets import DataUnion, shape_constraints, \
 import numpy as np
 
 rgba_image_shape = shape_constraints(None, None, 4)
+vmesh_shape = shape_constraints(None)
 
 @ipywidgets.register
 class ImageCanvas(ipywidgets.DOMWidget):
@@ -20,3 +21,30 @@ class ImageCanvas(ipywidgets.DOMWidget):
                     **data_union_serialization)
     width = traitlets.Int(256).tag(sync=True)
     height = traitlets.Int(256).tag(sync=True)
+
+@ipywidgets.register
+class FRBViewer(ipywidgets.DOMWidget):
+    """Viewing a fixed resolution buffer"""
+    _view_name = traitlets.Unicode('FRBView').tag(sync=True)
+    _model_name = traitlets.Unicode('FRBModel').tag(sync=True)
+    _view_module = traitlets.Unicode('yt-jscanvas').tag(sync=True)
+    _model_module = traitlets.Unicode('yt-jscanvas').tag(sync=True)
+    _view_module_version = traitlets.Unicode('^0.1.0').tag(sync=True)
+    _model_module_version = traitlets.Unicode('^0.1.0').tag(sync=True)
+    width = traitlets.Int(512).tag(sync=True)
+    height = traitlets.Int(512).tag(sync=True)
+    px = DataUnion(dtype=np.float64,
+            shape_constraint=vmesh_shape).tag(sync = True,
+                    **data_union_serialization)
+    py = DataUnion(dtype=np.float64,
+            shape_constraint=vmesh_shape).tag(sync = True,
+                    **data_union_serialization)
+    pdx = DataUnion(dtype=np.float64,
+            shape_constraint=vmesh_shape).tag(sync = True,
+                    **data_union_serialization)
+    pdy = DataUnion(dtype=np.float64,
+            shape_constraint=vmesh_shape).tag(sync = True,
+                    **data_union_serialization)
+    val = DataUnion(dtype=np.float64,
+            shape_constraint=vmesh_shape).tag(sync = True,
+                    **data_union_serialization)


### PR DESCRIPTION
This branch 
- loads matplotlib colormaps into wasm
- uses wasm to normalize an array based on a colormap choice
- has listeners set for a colormap name, so colormaps can be updated
- updates the canvas rendering if a new colormap is set
- will normalize an image array to viridis by default

(built with data-exp-lab/rust-yt-tools@247b08a2)