### PR TITLE
minor refactoring normalizer function and listeners in colormap widget

### DIFF
--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -15,7 +15,7 @@ var CMapModel = widgets.WidgetModel.extend({
             is_log: undefined,
             min_val: undefined, 
             max_val: undefined,
-            data: undefined, 
+            data_array: undefined, 
             image_array: undefined,
         });
     },
@@ -25,43 +25,47 @@ var CMapModel = widgets.WidgetModel.extend({
         this.is_log = this.get('is_log');
         this.min_val = this.get('min_val');
         this.max_val = this.get('max_val');
-        this.data = this.get('data').data;
+        this.data_array = this.get('data_array').data;
         this.image_array = this.get('image_array').data;
         
         widgets.WidgetModel.prototype.initialize.apply(this, arguments);
         console.log('initializing colormaps object in WASM');
+        console.log(this.data_array);
 
         console.log('setting up listeners');
         this.setupListeners();
         console.log('listeners done');
     },
 
-    normalize: function(name, buffer, take_log) {
+    normalize: function() {
         // normalizes a given buffer with a colormap name. Requires colormaps
         // to be loaded in to wasm, so requires add_mpl_colormaps to be called 
         // at this time.
-        
+        //
         var that = this;
         return this.get_cmaps().then(function(colormaps) {
             if (that.min_val) {
                 if (that.max_val) {
                     console.log('both min and max are user defined');
-                    array = colormaps.normalize_min_max(name, buffer, that.min_val, that.max_val, take_log);
+                    array = colormaps.normalize_min_max(that.map_name, that.data_array, 
+                            that.min_val, that.max_val, that.is_log);
                 } else {
                     console.log('min val defined, max val not defined');
-                    array = colormaps.normalize_min(name, buffer, that.min_val, take_log);
+                    array = colormaps.normalize_min(that.map_name, that.data_array, 
+                            that.min_val, that.is_log);
                 }
             } else if (that.max_val) {
                 console.log('max val defined, min val not defined');
-                array = colormaps.normalize_max(name, buffer, that.max_val, take_log);
+                array = colormaps.normalize_max(that.map_name, that.data_array, 
+                        that.max_val, that.is_log);
             } else {
                 console.log('neither max nor min defined');
-                array = colormaps.normalize(name, buffer, take_log);
+                array = colormaps.normalize(that.map_name, that.data_array, that.is_log);
             };
 
             // checking to see that the returned array and the data object 
             // are as expected. 
-            console.log(that.data);
+            console.log(that.data_array);
             console.log(array);
             
             // I sort of feel like this next line shouldn't be required if we 
@@ -76,7 +80,7 @@ var CMapModel = widgets.WidgetModel.extend({
             that.set('image_array', array).data;
             that.save_changes();
             return array
-        });
+        }.bind(this));
     },
 
     get_cmaps: function() {
@@ -116,18 +120,19 @@ var CMapModel = widgets.WidgetModel.extend({
         this.on('change:is_log', this.scale_changed, this);
         this.on('change:min_val', this.limits_changed, this);
         this.on('change:max_val', this.limits_changed, this);
-        this.on('change:data', this.property_changed, this);
+        this.on('change:data_array', this.property_changed, this);
 
         // setting up js listener for change in the input data array since
         // the js side of the frb and the image canvas modify it. 
-        this.listenTo(this, 'change:data', this.jsdata_changed(), this);
+        this.listenTo(this, 'change:data_array', this.jsdata_changed(), this);
     },
 
     name_changed: function() {
         var old_name = this.map_name;
         this.map_name = this.get('map_name');
         console.log('triggered name event listener: name from %s to %s', old_name, this.map_name);
-        return this.normalize(this.map_name, this.data, this.is_log).then(function(array){
+        // console.log(this.map_name, this.is_log, this.min_val, this.max_val); 
+        return this.normalize().then(function(array){
             return array;
         });
     },
@@ -136,16 +141,18 @@ var CMapModel = widgets.WidgetModel.extend({
         var old_scale = this.is_log;
         this.is_log = this.get('is_log');
         console.log('triggered scale event listener: log from %s to %s', old_scale, this.is_log);
-        return this.normalize(this.map_name, this.data, this.is_log).then(function(array){
+        // console.log(this.map_name, this.is_log, this.min_val, this.max_val); 
+        return this.normalize().then(function(array){
+            this.image_array = array;
             return array;
-        });
+        }.bind(this));
     },
     
     limits_changed: function() {
         this.min_val = this.get('min_val');
         this.max_val = this.get('max_val');
         console.log('triggered limit event listener: min and max val', this.min_val, this.max_val);
-        return this.normalize(this.map_name, this.data, this.is_log).then(function(array){
+        return this.normalize().then(function(array){
             return array;
         });
     },
@@ -153,7 +160,7 @@ var CMapModel = widgets.WidgetModel.extend({
     property_changed: function() {
         this.data = this.get('data').data;
         console.log('detected change in buffer array on python side. Renormalizing');
-        return this.normalize(this.map_name, this.data, this.is_log).then(function(array){
+        return this.normalize().then(function(array){
             return array;
         });
     },
@@ -161,7 +168,7 @@ var CMapModel = widgets.WidgetModel.extend({
     jsdata_changed: function() {
         console.log(this.data);
         console.log('detected change in buffer array on js side. Renormalizing');
-        return this.normalize(this.map_name, this.data, this.is_log).then(function(array){
+        return this.normalize().then(function(array){
             return array;
         });
     },

--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -80,7 +80,7 @@ var CMapModel = widgets.WidgetModel.extend({
             that.set('image_array', array).data;
             that.save_changes();
             return array
-        }.bind(this));
+        });
     },
 
     get_cmaps: function() {
@@ -131,46 +131,33 @@ var CMapModel = widgets.WidgetModel.extend({
         var old_name = this.map_name;
         this.map_name = this.get('map_name');
         console.log('triggered name event listener: name from %s to %s', old_name, this.map_name);
-        // console.log(this.map_name, this.is_log, this.min_val, this.max_val); 
-        return this.normalize().then(function(array){
-            return array;
-        });
+        this.normalize();
     },
     
     scale_changed: function() {
         var old_scale = this.is_log;
         this.is_log = this.get('is_log');
         console.log('triggered scale event listener: log from %s to %s', old_scale, this.is_log);
-        // console.log(this.map_name, this.is_log, this.min_val, this.max_val); 
-        return this.normalize().then(function(array){
-            this.image_array = array;
-            return array;
-        }.bind(this));
+        this.normalize();
     },
     
     limits_changed: function() {
         this.min_val = this.get('min_val');
         this.max_val = this.get('max_val');
         console.log('triggered limit event listener: min and max val', this.min_val, this.max_val);
-        return this.normalize().then(function(array){
-            return array;
-        });
+        this.normalize();
     },
 
     property_changed: function() {
-        this.data = this.get('data').data;
+        this.data = this.get('data_array').data;
         console.log('detected change in buffer array on python side. Renormalizing');
-        return this.normalize().then(function(array){
-            return array;
-        });
+        this.normalize();
     },
     
     jsdata_changed: function() {
-        console.log(this.data);
+        console.log(this.data_array);
         console.log('detected change in buffer array on js side. Renormalizing');
-        return this.normalize().then(function(array){
-            return array;
-        });
+        this.normalize();
     },
 }, {
    serializers: _.extend({

--- a/js/lib/fixed_res_buffer.js
+++ b/js/lib/fixed_res_buffer.js
@@ -61,7 +61,7 @@ var FRBView = widgets.DOMWidgetView.extend({
                 this.model.get("val").data
             );
             this.frb.deposit(this.varmesh);
-            this.colormaps.data = this.frb.get_buffer();
+            this.colormaps.data_array = this.frb.get_buffer();
             this.imageData = this.ctx.createImageData(
                 this.model.get('width'), this.model.get('height'),
             );

--- a/yt_pycanvas/colormaps/colormaps.py
+++ b/yt_pycanvas/colormaps/colormaps.py
@@ -21,7 +21,7 @@ class ColorMaps(ipywidgets.Widget):
     is_log = traitlets.Bool(False).tag(sync=True, config=True)
     min_val = traitlets.Float().tag(sync=True, config=True)
     max_val = traitlets.Float().tag(sync=True, config=True)
-    data = DataUnion(np.array([]), dtype=np.float64,
+    data_array = DataUnion(np.array([]), dtype=np.float64,
             shape_constraint=vmesh_shape).tag(sync = True, config=True,
                     **data_union_serialization)
     image_array = DataUnion(np.array([]), dtype=np.uint8,


### PR DESCRIPTION
The `normalize()` function now uses the Model-level variables for map_name, min and max vals, is_log, and data_array rather than taking arguments. This function already modifies a Model-level variable (the image_array), so this ensures consistency within the Model. 

The js and python listeners for the Model variables in the colormap widget originally returned a promise from the normalizer. Now they call normalize but don't return the promise. 