### PR TITLE
Make async things a bit nicer

### DIFF
--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -1,6 +1,6 @@
 var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
-var yt_tools = require('@data-exp-lab/yt-tools');
+var yt_tools = import('@data-exp-lab/yt-tools');
 
 var CMapModel = widgets.WidgetModel.extend({
 
@@ -21,20 +21,24 @@ var CMapModel = widgets.WidgetModel.extend({
     },
 
     initialize: function() {
-        this.map_name = this.get('map_name');
-        this.is_log = this.get('is_log');
-        this.min_val = this.get('min_val');
-        this.max_val = this.get('max_val');
-        this.data_array = this.get('data_array').data;
-        this.image_array = this.get('image_array').data;
-        
         widgets.WidgetModel.prototype.initialize.apply(this, arguments);
-        console.log('initializing colormaps object in WASM');
-        console.log(this.data_array);
+        var that = this;
+        yt_tools.then(function(yt_tools) {
+          that.yt_tools = yt_tools;
+          that.map_name = that.get('map_name');
+          that.is_log = that.get('is_log');
+          that.min_val = that.get('min_val');
+          that.max_val = that.get('max_val');
+          that.data_array = that.get('data_array').data;
+          that.image_array = that.get('image_array').data;
+          
+          console.log('initializing colormaps object in WASM');
+          console.log(that.data_array);
 
-        console.log('setting up listeners');
-        this.setupListeners();
-        console.log('listeners done');
+          console.log('setting up listeners');
+          that.setupListeners();
+          console.log('listeners done');
+        });
     },
 
     normalize: function() {
@@ -43,44 +47,43 @@ var CMapModel = widgets.WidgetModel.extend({
         // at this time.
         //
         var that = this;
-        return this.get_cmaps().then(function(colormaps) {
-            if (that.min_val) {
-                if (that.max_val) {
-                    console.log('both min and max are user defined');
-                    array = colormaps.normalize_min_max(that.map_name, that.data_array, 
-                            that.min_val, that.max_val, that.is_log);
-                } else {
-                    console.log('min val defined, max val not defined');
-                    array = colormaps.normalize_min(that.map_name, that.data_array, 
-                            that.min_val, that.is_log);
-                }
-            } else if (that.max_val) {
-                console.log('max val defined, min val not defined');
-                array = colormaps.normalize_max(that.map_name, that.data_array, 
-                        that.max_val, that.is_log);
+        var colormaps = this.get_cmaps();
+        if (this.min_val) {
+            if (this.max_val) {
+                console.log('both min and max are user defined');
+                array = colormaps.normalize_min_max(this.map_name, this.data_array, 
+                        this.min_val, this.max_val, this.is_log);
             } else {
-                console.log('neither max nor min defined');
-                array = colormaps.normalize(that.map_name, that.data_array, that.is_log);
-            };
+                console.log('min val defined, max val not defined');
+                array = colormaps.normalize_min(this.map_name, this.data_array, 
+                        this.min_val, this.is_log);
+            }
+        } else if (this.max_val) {
+            console.log('max val defined, min val not defined');
+            array = colormaps.normalize_max(this.map_name, this.data_array, 
+                    this.max_val, this.is_log);
+        } else {
+            console.log('neither max nor min defined');
+            array = colormaps.normalize(this.map_name, this.data_array, this.is_log);
+        };
 
-            // checking to see that the returned array and the data object 
-            // are as expected. 
-            console.log(that.data_array);
-            console.log(array);
-            
-            // I sort of feel like this next line shouldn't be required if we 
-            // update the Python side, but whatever. 
-            // Updates the js side of image_array to our result. 
-            that.image_array = array;
+        // checking to see that the returned array and the data object 
+        // are as expected. 
+        console.log(this.data_array);
+        console.log(array);
+        
+        // I sort of feel like this next line shouldn't be required if we 
+        // update the Python side, but whatever. 
+        // Updates the js side of image_array to our result. 
+        this.image_array = array;
 
-            // this sync isn't working yet, so on the python side we can't 
-            // access it. 
-            // However, in order for the FRB to pick up that something changed 
-            // in the image array, that.set must be used.  
-            that.set('image_array', array).data;
-            that.save_changes();
-            return array
-        });
+        // this sync isn't working yet, so on the python side we can't 
+        // access it. 
+        // However, in order for the FRB to pick up that something changed 
+        // in the image array, this.set must be used.  
+        this.set('image_array', array).data;
+        this.save_changes();
+        return array
     },
 
     get_cmaps: function() {
@@ -88,28 +91,25 @@ var CMapModel = widgets.WidgetModel.extend({
         // arrays stored in the self.cmaps dict on the python side into
         // the colormaps object in wasm.
         
-        var that = this
-        return yt_tools.booted.then(function(yt_tools) {
-            console.log('checking to see if colormaps object for wasm exists..... ');
-            if (that.colormaps) {
-                console.log('colormaps exist');
-                console.log(that.colormaps);
-                return that.colormaps
-            } else {
-                console.log('colormaps DO NOT exist..... importing....... ');
-                that.colormaps = yt_tools.Colormaps.new();
-        
-                var mpl_cmap_obj = that.get('cmaps');
-                console.log("imported the following maps:", Object.keys(mpl_cmap_obj));
-                for (var mapname in mpl_cmap_obj) {
-                    if (mpl_cmap_obj.hasOwnProperty(mapname)) {
-                        var maptable = mpl_cmap_obj[mapname];
-                        that.colormaps.add_colormap(mapname, maptable);
-                    }
+        console.log('checking to see if colormaps object for wasm exists..... ');
+        if (this.colormaps) {
+            console.log('colormaps exist');
+            console.log(this.colormaps);
+            return this.colormaps
+        } else {
+            console.log('colormaps DO NOT exist..... importing....... ');
+            this.colormaps = new this.yt_tools.Colormaps();
+    
+            var mpl_cmap_obj = this.get('cmaps');
+            console.log("imported the following maps:", Object.keys(mpl_cmap_obj));
+            for (var mapname in mpl_cmap_obj) {
+                if (mpl_cmap_obj.hasOwnProperty(mapname)) {
+                    var maptable = mpl_cmap_obj[mapname];
+                    this.colormaps.add_colormap(mapname, maptable);
                 }
-                return that.colormaps
             }
-        });
+            return this.colormaps
+        }
     }, 
     
     setupListeners: function() {

--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -93,7 +93,7 @@ var CMapModel = widgets.WidgetModel.extend({
             return this.colormaps
         } else {
             console.log('colormaps DO NOT exist..... importing....... ');
-            this.colormaps = new yt_tools.Colormaps();
+            this.colormaps = yt_tools.Colormaps.new();
     
             var mpl_cmap_obj = this.get('cmaps');
             console.log("imported the following maps:", Object.keys(mpl_cmap_obj));

--- a/js/lib/fixed_res_buffer.js
+++ b/js/lib/fixed_res_buffer.js
@@ -1,6 +1,6 @@
 var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
-var yt_tools = import('@data-exp-lab/yt-tools');
+var _yt_tools = import('@data-exp-lab/yt-tools');
 
 var FRBModel = widgets.DOMWidgetModel.extend({
     defaults: _.extend({}, widgets.DOMWidgetModel.prototype.defaults, {
@@ -32,15 +32,8 @@ var FRBModel = widgets.DOMWidgetModel.extend({
 
 // Custom View. Renders the widget model.
 var FRBView = widgets.DOMWidgetView.extend({
-    initialize: function() {
-        widgets.WidgetModel.prototype.initialize.apply(this, arguments);
-        var that = this;
-        yt_tools.then(function(yt_tools) {
-          that.yt_tools = yt_tools;
-        });
-    },
 
-    render: function() {
+    render: function() {return _yt_tools.then(function(yt_tools) {
         this.canvas = document.createElement('canvas');
         $(this.canvas)
           .css("max-width", "100%")
@@ -53,15 +46,14 @@ var FRBView = widgets.DOMWidgetView.extend({
         this.ctx.imageSmoothingEnabled = false;
         this.model.on('change:width', this.width_changed, this);
         this.model.on('change:height', this.height_changed, this);
-        yt_tools.then(() => {
             this.colormaps = this.model.get('colormaps');
             this.colormap_events();
-            this.frb = new this.yt_tools.FixedResolutionBuffer(
+            this.frb = new yt_tools.FixedResolutionBuffer(
                 this.model.get('width'),
                 this.model.get('height'),
                 0.45, 0.65, 0.45, 0.65
             );
-            this.varmesh = new this.yt_tools.VariableMesh(
+            this.varmesh = new yt_tools.VariableMesh(
                 this.model.get("px").data,
                 this.model.get("py").data,
                 this.model.get("pdx").data,
@@ -79,7 +71,7 @@ var FRBView = widgets.DOMWidgetView.extend({
             console.log(this.colormaps.image_array);
             this.imageData.data.set(this.colormaps.image_array);
             this.redrawCanvasImage();
-        });
+        }.bind(this));
     },
 
     redrawCanvasImage: function() {

--- a/js/lib/fixed_res_buffer.js
+++ b/js/lib/fixed_res_buffer.js
@@ -48,12 +48,12 @@ var FRBView = widgets.DOMWidgetView.extend({
         this.model.on('change:height', this.height_changed, this);
             this.colormaps = this.model.get('colormaps');
             this.colormap_events();
-            this.frb = new yt_tools.FixedResolutionBuffer(
+            this.frb = yt_tools.FixedResolutionBuffer.new(
                 this.model.get('width'),
                 this.model.get('height'),
                 0.45, 0.65, 0.45, 0.65
             );
-            this.varmesh = new yt_tools.VariableMesh(
+            this.varmesh = yt_tools.VariableMesh.new(
                 this.model.get("px").data,
                 this.model.get("py").data,
                 this.model.get("pdx").data,

--- a/js/lib/fixed_res_buffer.js
+++ b/js/lib/fixed_res_buffer.js
@@ -1,6 +1,6 @@
 var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
-var yt_tools = require('@data-exp-lab/yt-tools');
+var yt_tools = import('@data-exp-lab/yt-tools');
 
 var FRBModel = widgets.DOMWidgetModel.extend({
     defaults: _.extend({}, widgets.DOMWidgetModel.prototype.defaults, {
@@ -32,6 +32,14 @@ var FRBModel = widgets.DOMWidgetModel.extend({
 
 // Custom View. Renders the widget model.
 var FRBView = widgets.DOMWidgetView.extend({
+    initialize: function() {
+        widgets.WidgetModel.prototype.initialize.apply(this, arguments);
+        var that = this;
+        yt_tools.then(function(yt_tools) {
+          that.yt_tools = yt_tools;
+        });
+    },
+
     render: function() {
         this.canvas = document.createElement('canvas');
         $(this.canvas)
@@ -45,15 +53,15 @@ var FRBView = widgets.DOMWidgetView.extend({
         this.ctx.imageSmoothingEnabled = false;
         this.model.on('change:width', this.width_changed, this);
         this.model.on('change:height', this.height_changed, this);
-        yt_tools.booted.then(function(yt_tools) {
+        yt_tools.then(() => {
             this.colormaps = this.model.get('colormaps');
             this.colormap_events();
-            this.frb = yt_tools.FixedResolutionBuffer.new(
+            this.frb = new this.yt_tools.FixedResolutionBuffer(
                 this.model.get('width'),
                 this.model.get('height'),
                 0.45, 0.65, 0.45, 0.65
             );
-            this.varmesh = yt_tools.VariableMesh.new(
+            this.varmesh = new this.yt_tools.VariableMesh(
                 this.model.get("px").data,
                 this.model.get("py").data,
                 this.model.get("pdx").data,
@@ -71,7 +79,7 @@ var FRBView = widgets.DOMWidgetView.extend({
             console.log(this.colormaps.image_array);
             this.imageData.data.set(this.colormaps.image_array);
             this.redrawCanvasImage();
-        }.bind(this));
+        });
     },
 
     redrawCanvasImage: function() {

--- a/js/lib/fixed_res_buffer.js
+++ b/js/lib/fixed_res_buffer.js
@@ -46,33 +46,32 @@ var FRBView = widgets.DOMWidgetView.extend({
         this.ctx.imageSmoothingEnabled = false;
         this.model.on('change:width', this.width_changed, this);
         this.model.on('change:height', this.height_changed, this);
-            this.colormaps = this.model.get('colormaps');
-            this.colormap_events();
-            this.frb = yt_tools.FixedResolutionBuffer.new(
-                this.model.get('width'),
-                this.model.get('height'),
-                0.45, 0.65, 0.45, 0.65
-            );
-            this.varmesh = yt_tools.VariableMesh.new(
-                this.model.get("px").data,
-                this.model.get("py").data,
-                this.model.get("pdx").data,
-                this.model.get("pdy").data,
-                this.model.get("val").data
-            );
-            this.frb.deposit(this.varmesh);
-            this.colormaps.data_array = this.frb.get_buffer();
-            this.imageData = this.ctx.createImageData(
-                this.model.get('width'), this.model.get('height'),
-            );
-            // note: image array not triggering change yet on first render. 
-            // this is likely due to the fact that it's executed before the 
-            // new promises have been resolved in the colormapper
-            console.log(this.colormaps.image_array);
-            this.imageData.data.set(this.colormaps.image_array);
-            this.redrawCanvasImage();
-        }.bind(this));
-    },
+        this.colormaps = this.model.get('colormaps');
+        this.colormap_events();
+        this.frb = yt_tools.FixedResolutionBuffer.new(
+            this.model.get('width'),
+            this.model.get('height'),
+            0.45, 0.65, 0.45, 0.65
+        );
+        this.varmesh = yt_tools.VariableMesh.new(
+            this.model.get("px").data,
+            this.model.get("py").data,
+            this.model.get("pdx").data,
+            this.model.get("pdy").data,
+            this.model.get("val").data
+        );
+        this.frb.deposit(this.varmesh);
+        this.colormaps.data_array = this.frb.get_buffer();
+        this.imageData = this.ctx.createImageData(
+            this.model.get('width'), this.model.get('height'),
+        );
+        // note: image array not triggering change yet on first render. 
+        // this is likely due to the fact that it's executed before the 
+        // new promises have been resolved in the colormapper
+        console.log(this.colormaps.image_array);
+        this.imageData.data.set(this.colormaps.image_array);
+        this.redrawCanvasImage();
+    }.bind(this));},
 
     redrawCanvasImage: function() {
         var nx = this.model.get('width');

--- a/js/lib/image_canvas.js
+++ b/js/lib/image_canvas.js
@@ -1,6 +1,6 @@
 var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
-var yt_tools = require('@data-exp-lab/yt-tools');
+var yt_tools = import('@data-exp-lab/yt-tools');
 var frb = require('./fixed_res_buffer.js');
 var cmaps = require('./colormaps.js')
 

--- a/js/lib/image_canvas.js
+++ b/js/lib/image_canvas.js
@@ -1,6 +1,5 @@
 var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
-var yt_tools = import('@data-exp-lab/yt-tools');
 var frb = require('./fixed_res_buffer.js');
 var cmaps = require('./colormaps.js')
 

--- a/js/package.json
+++ b/js/package.json
@@ -38,9 +38,9 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "webpack": "^4.8.3",
-    "webpack-cli": "^2.0.14",
-    "rimraf": "^2.6.1"
+    "rimraf": "^2.6.1",
+    "webpack": "^4.12.0",
+    "webpack-cli": "^2.1.5"
   },
   "dependencies": {
     "@data-exp-lab/yt-tools": "^0.1.0",

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -5,8 +5,7 @@ var version = require('./package.json').version;
 // stored in a separate local variable.
 var rules = [
     { test: /\.css$/, use: ['style-loader', 'css-loader'] },
-    { test: /\.wasm$/, type: 'javascript/auto', loader: "file-loader" }
-    //{ test: /\.wasm$/, type: 'webassembly/experimental' }
+    { test: /\.wasm$/, type: 'webassembly/experimental' }
 ]
 
 


### PR DESCRIPTION
This switches to using the `import` operation to bring in the webassembly.  We can delay some things, like initialization of listeners (so no operations can happen on colormaps until that happens) but it looks like the `render` operation for fixed res still needs a promise.

Alternately, a considerably safer thing to do might be to wrap all our functions in promises that may be immediately resolved; for instance:

```
someFunction: function(){ return yt_tools.then( (yt_tools) => {
...
})})
```