### PR TITLE
Adds navigation functionality, listeners in FRB

### DIFF
--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -28,13 +28,8 @@ var CMapModel = widgets.WidgetModel.extend({
         this.max_val = this.get('max_val');
         this.data_array = this.get('data_array').data;
         this.image_array = this.get('image_array').data;
-        
-        console.log('initializing colormaps object in WASM');
-        console.log(this.data_array);
 
-        console.log('setting up listeners');
         this.setupListeners();
-        console.log('listeners done');
     },
 
     normalize: function() {return _yt_tools.then(function(yt_tools) {
@@ -45,27 +40,18 @@ var CMapModel = widgets.WidgetModel.extend({
         var colormaps = this.get_cmaps(yt_tools);
         if (this.min_val) {
             if (this.max_val) {
-                console.log('both min and max are user defined');
                 array = colormaps.normalize_min_max(this.map_name, this.data_array, 
                         this.min_val, this.max_val, this.is_log);
             } else {
-                console.log('min val defined, max val not defined');
                 array = colormaps.normalize_min(this.map_name, this.data_array, 
                         this.min_val, this.is_log);
             }
         } else if (this.max_val) {
-            console.log('max val defined, min val not defined');
             array = colormaps.normalize_max(this.map_name, this.data_array, 
                     this.max_val, this.is_log);
         } else {
-            console.log('neither max nor min defined');
             array = colormaps.normalize(this.map_name, this.data_array, this.is_log);
         };
-
-        // checking to see that the returned array and the data object 
-        // are as expected. 
-        console.log(this.data_array);
-        console.log(array);
         
         // I sort of feel like this next line shouldn't be required if we 
         // update the Python side, but whatever. 
@@ -86,17 +72,14 @@ var CMapModel = widgets.WidgetModel.extend({
         // arrays stored in the self.cmaps dict on the python side into
         // the colormaps object in wasm.
         
-        console.log('checking to see if colormaps object for wasm exists..... ');
         if (this.colormaps) {
             console.log('colormaps exist');
-            console.log(this.colormaps);
             return this.colormaps
         } else {
-            console.log('colormaps DO NOT exist..... importing....... ');
+            console.log('importing colormaps into wasm... ');
             this.colormaps = yt_tools.Colormaps.new();
     
             var mpl_cmap_obj = this.get('cmaps');
-            console.log("imported the following maps:", Object.keys(mpl_cmap_obj));
             for (var mapname in mpl_cmap_obj) {
                 if (mpl_cmap_obj.hasOwnProperty(mapname)) {
                     var maptable = mpl_cmap_obj[mapname];
@@ -108,7 +91,7 @@ var CMapModel = widgets.WidgetModel.extend({
     }, 
     
     setupListeners: function() {
-        console.log('in setup_listeners function');
+        console.log('setting up listeners for trait changes');
         
         // setting up listeners on the python side.
         this.on('change:map_name', this.name_changed, this);
@@ -150,7 +133,6 @@ var CMapModel = widgets.WidgetModel.extend({
     },
     
     jsdata_changed: function() {
-        console.log(this.data_array);
         console.log('detected change in buffer array on js side. Renormalizing');
         this.normalize();
     },

--- a/js/lib/fixed_res_buffer.js
+++ b/js/lib/fixed_res_buffer.js
@@ -137,14 +137,9 @@ var FRBView = widgets.DOMWidgetView.extend({
             );
             this.frb.deposit(this.varmesh);
             this.colormaps.data_array = this.frb.get_buffer();
+            // data array not triggering listeners in colormaps. 
+            // Normalize() call required to update image array. 
             this.colormaps.normalize();
-            console.log(this.colormaps.data_array);
-            this.imageData = this.ctx.createImageData(
-                this.model.get('width'), this.model.get('height'),
-            );
-            console.log(this.colormaps.image_array);
-            this.imageData.data.set(this.colormaps.image_array);
-            this.redrawCanvasImage();
         }.bind(this));
     },
 

--- a/js/lib/fixed_res_buffer.js
+++ b/js/lib/fixed_res_buffer.js
@@ -70,10 +70,6 @@ var FRBView = widgets.DOMWidgetView.extend({
         this.imageData = this.ctx.createImageData(
             this.model.get('width'), this.model.get('height'),
         );
-        // note: image array not triggering change yet on first render. 
-        // this is likely due to the fact that it's executed before the 
-        // new promises have been resolved in the colormapper
-        console.log(this.colormaps.image_array);
         this.imageData.data.set(this.colormaps.image_array);
         this.redrawCanvasImage();
     }.bind(this));},
@@ -95,11 +91,9 @@ var FRBView = widgets.DOMWidgetView.extend({
         // links to these directly so the responses are simple. 
         this.listenTo(this.colormaps, 'change:map_name', function() {
             var new_name = this.colormaps.get('map_name');
-            console.log('map name change detected in frb to %s', new_name);
         }, this); 
         this.listenTo(this.colormaps, 'change:is_log', function() {
             var scale = this.colormaps.get('is_log');
-            console.log('image array log scale change in frb to %s', scale);
         }, this); 
 
         // The listener for the data array of the colormap actually links to the 
@@ -112,7 +106,7 @@ var FRBView = widgets.DOMWidgetView.extend({
         // it on the canvas image. 
         this.listenTo(this.colormaps, 'change:image_array', function() {
             var array = this.colormaps.get('image_array');
-            console.log('image array updated to: ', array);
+            console.log('image array updated');
             this.imageData = this.ctx.createImageData(
                 this.model.get('width'), this.model.get('height'),
             );

--- a/yt_pycanvas/image_canvas.py
+++ b/yt_pycanvas/image_canvas.py
@@ -53,7 +53,7 @@ class FRBViewer(ipywidgets.DOMWidget):
                     **data_union_serialization)
     colormaps = traitlets.Instance(ColorMaps).tag(sync = True,
             **widget_serialization)
-    canvas_edges = traitlets.List([0.45, 0.65, 0.45, 0.65]).tag(sync = True,
+    canvas_edges = traitlets.Tuple((0.45, 0.65, 0.45, 0.65)).tag(sync = True,
             config=True)
 
     @traitlets.default('colormaps')
@@ -75,26 +75,18 @@ class FRBViewer(ipywidgets.DOMWidget):
         return all_buttons
 
     def on_xdownclick(self, b):
-        array = self.canvas_edges.copy()
-        array[0] += 0.01
-        array[1] += 0.01
-        self.canvas_edges = array
+        ce = self.canvas_edges
+        self.canvas_edges = (ce[0]+0.01, ce[1]+0.01)+ce[2:]
 
     def on_xupclick(self, b):
-        array = self.canvas_edges.copy()
-        array[0] -= 0.01
-        array[1] -= 0.01
-        self.canvas_edges = array
+        ce = self.canvas_edges
+        self.canvas_edges = (ce[0]-0.01, ce[1]-0.01)+ce[2:]
 
     def on_yrightclick(self, b):
-        array = self.canvas_edges.copy()
-        array[2] += 0.01
-        array[3] += 0.01
-        self.canvas_edges = array
+        ce = self.canvas_edges
+        self.canvas_edges = ce[:2]+(ce[2]+0.01, ce[3]+0.01)
 
     def on_yleftclick(self, b):
-        array = self.canvas_edges.copy()
-        array[2] -= 0.01
-        array[3] -= 0.01
-        self.canvas_edges = array
+        ce = self.canvas_edges
+        self.canvas_edges = ce[:2]+(ce[2]-0.01, ce[3]-0.01)
 

--- a/yt_pycanvas/image_canvas.py
+++ b/yt_pycanvas/image_canvas.py
@@ -62,14 +62,14 @@ class FRBViewer(ipywidgets.DOMWidget):
 
     def setup_controls(self):
         down = ipywidgets.Button(icon="arrow-down",
-                layout=ipywidgets.Layout(width='10%'))
+                layout=ipywidgets.Layout(width='40px'))
         up = ipywidgets.Button(icon="arrow-up",
-                layout=ipywidgets.Layout(width='10%'))
+                layout=ipywidgets.Layout(width='40px'))
         right = ipywidgets.Button(icon="arrow-right",
-                layout=ipywidgets.Layout(width='30%')
+                layout=ipywidgets.Layout(width='40px')
                 )
         left = ipywidgets.Button(icon="arrow-left",
-                layout=ipywidgets.Layout(width='30%')
+                layout=ipywidgets.Layout(width='40px')
                 )
         zoom = ipywidgets.FloatSlider(min=1, max=10, step=0.1, description="Zoom")
         is_log = ipywidgets.Checkbox(value=False, description="Log colorscale")
@@ -96,12 +96,11 @@ class FRBViewer(ipywidgets.DOMWidget):
 
         sides = ipywidgets.HBox([left,right],
                 layout=ipywidgets.Layout(justify_content='space-between',
-                    width='30%'))
+                    width='122px'))
         nav_buttons = ipywidgets.VBox([up, sides, down],
                 layout=ipywidgets.Layout(
                     align_items='center',
-                    width='100%'))
-
+                    width='150px'))
 
         all_navigation = ipywidgets.VBox([nav_buttons, zoom],
                 layout=ipywidgets.Layout(align_items='center')

--- a/yt_pycanvas/image_canvas.py
+++ b/yt_pycanvas/image_canvas.py
@@ -60,4 +60,41 @@ class FRBViewer(ipywidgets.DOMWidget):
     def _colormap_load(self):
         return ColorMaps()
 
+    def setup_controls(self):
+        down = ipywidgets.Button(description="Down")
+        up = ipywidgets.Button(description="Up")
+        right = ipywidgets.Button(description="Right")
+        left = ipywidgets.Button(description="Left")
+
+        down.on_click(self.on_xdownclick)
+        up.on_click(self.on_xupclick)
+        right.on_click(self.on_yrightclick)
+        left.on_click(self.on_yleftclick)
+
+        all_buttons = ipywidgets.VBox([down,up,left,right])
+        return all_buttons
+
+    def on_xdownclick(self, b):
+        array = self.canvas_edges.copy()
+        array[0] += 0.01
+        array[1] += 0.01
+        self.canvas_edges = array
+
+    def on_xupclick(self, b):
+        array = self.canvas_edges.copy()
+        array[0] -= 0.01
+        array[1] -= 0.01
+        self.canvas_edges = array
+
+    def on_yrightclick(self, b):
+        array = self.canvas_edges.copy()
+        array[2] += 0.01
+        array[3] += 0.01
+        self.canvas_edges = array
+
+    def on_yleftclick(self, b):
+        array = self.canvas_edges.copy()
+        array[2] -= 0.01
+        array[3] -= 0.01
+        self.canvas_edges = array
 

--- a/yt_pycanvas/image_canvas.py
+++ b/yt_pycanvas/image_canvas.py
@@ -65,13 +65,16 @@ class FRBViewer(ipywidgets.DOMWidget):
         up = ipywidgets.Button(description="Up")
         right = ipywidgets.Button(description="Right")
         left = ipywidgets.Button(description="Left")
+        zoom = ipywidgets.FloatSlider(min=1, max=10, value=0.1, description="Zoom")
+
 
         down.on_click(self.on_xdownclick)
         up.on_click(self.on_xupclick)
         right.on_click(self.on_yrightclick)
         left.on_click(self.on_yleftclick)
+        zoom.observe(self.on_zoom, names='value')
 
-        all_buttons = ipywidgets.VBox([down,up,left,right])
+        all_buttons = ipywidgets.VBox([down,up,left,right, zoom])
         return all_buttons
 
     def on_xdownclick(self, b):
@@ -89,4 +92,19 @@ class FRBViewer(ipywidgets.DOMWidget):
     def on_yleftclick(self, b):
         ce = self.canvas_edges
         self.canvas_edges = ce[:2]+(ce[2]-0.01, ce[3]-0.01)
+
+    def on_zoom(self, change):
+        ce = self.canvas_edges
+        lengths = [ce[1]-ce[0], ce[3]-ce[2]]
+        center = [np.mean(ce[:2]), np.mean(ce[2:])]
+        width = 1.0/change["new"]
+        hwidth = width/2.
+        new_edges = (center[0]-hwidth, center[0]+hwidth, center[1]-hwidth,
+                center[1]+hwidth)
+        self.canvas_edges = new_edges
+        print("canvas center is at: {}".format(center))
+        # print("zoom value is: {}".format(change["new"]))
+        # print("width of frame is: {}".format(width))
+        # print("old edges: {} \n new edges:{}".format(ce, new_edges))
+
 

--- a/yt_pycanvas/image_canvas.py
+++ b/yt_pycanvas/image_canvas.py
@@ -53,8 +53,11 @@ class FRBViewer(ipywidgets.DOMWidget):
                     **data_union_serialization)
     colormaps = traitlets.Instance(ColorMaps).tag(sync = True,
             **widget_serialization)
+    canvas_edges = traitlets.List([0.45, 0.65, 0.45, 0.65]).tag(sync = True,
+            config=True)
 
     @traitlets.default('colormaps')
     def _colormap_load(self):
         return ColorMaps()
+
 


### PR DESCRIPTION
Has the following features:
* new trait for FRB called canvas_edges that defines the x and y low and high values for the frb
* on changes in this trait, function called `buffer_changed` in `fixed_res_buffer.js` is triggered. This creates a new frb object and deposits it into the varmesh
* The `FRBViewer` class in `image_canvas.py` now has a function called `setup_controls()` that returns an accordion with colormap and navigation widgets linked to the colormap and navigation-related traits in the FRB. These include:
   * zoom option
   * navigation buttons for up, down, left and right
   * colormap name
   * min and max values for the colormap
   * is_log value for colormap scaling






Resolves #8 